### PR TITLE
Update markdown formatting in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ You may also be interested in a forked version of this codebase available at htt
 * PHP
 * Pandoc
 
-
 ## Export MediaWiki Pages
 
 You'll export all your pages as a single XML file following these steps: http://en.wikipedia.org/wiki/Help:Export
-
 
 ## Installation
 
@@ -25,42 +23,50 @@ http://johnmacfarlane.net/pandoc/installing.html
 
 ### Get Composer
 
-`curl -sS https://getcomposer.org/installer | php`
-
+```bash
+curl -sS https://getcomposer.org/installer | php
+```
 
 ### Install Composer Packages
 
-`php composer.phar install`
-
+```bash
+php composer.phar install
+```
 
 ## Run
 
-####--filename####
+#### `--filename` ####
 The only required parameter is `filename` for the name of the xml file you exported from MediaWiki, eg: 
 
 `php convert.php --filename=mediawiki.xml`
 
-####--output####
+#### `--output` ####
 You can also use `output` to specify an output folder since each wiki page in the XML file will generate it's own separate markdown file.
 
-`php convert.php --filename=mediawiki.xml --output=export`
+```bash
+php convert.php --filename=mediawiki.xml --output=export
+```
 
-
-####--indexes####
+#### `--indexes` ####
 You can set `indexes` as `true` if you want pages with the same name as a directory to be renamed as index.md and placed into their directory
 
-`php convert.php --filename=mediawiki.xml --output=export --indexes=true`
+```bash
+php convert.php --filename=mediawiki.xml --output=export --indexes=true
+```
 
-####--frontmatter####
+#### `--frontmatter` ####
 You can specify whether you want frontmatter included. This is automatically set to `true` when the output format is `markdown_github`
 
-`php convert.php --filename=mediawiki.xml --output=export --format=markdown_phpextra --frontmatter=true`
+```bash
+php convert.php --filename=mediawiki.xml --output=export --format=markdown_phpextra --frontmatter=true
+```
 
-
-####--format####
+#### `--format` ####
 You can specify different output formats with `format`. The default is `markdown_github`. See 
 
-`php convert.php --filename=mediawiki.xml --output=export --format=markdown_phpextra`
+```bash
+php convert.php --filename=mediawiki.xml --output=export --format=markdown_phpextra
+```
 
 Supported pandoc formats are: 
 


### PR DESCRIPTION
- Add spaces after # marks to support recent GitHub-flavored Markdown change.
- Add syntax highlighting tags to code blocks.
- Add backticks to get monospace rendering for flags.